### PR TITLE
remove hard coded schema name in sql scripts

### DIFF
--- a/online-building-plan-approval-system/bpa-services/src/main/resources/db/migration/main/V20200515102355__bpa_create.sql
+++ b/online-building-plan-approval-system/bpa-services/src/main/resources/db/migration/main/V20200515102355__bpa_create.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS  eg_bpa_buildingplan(
 );
 
 
-CREATE TABLE IF NOT EXISTS  public.eg_bpa_auditdetails(
+CREATE TABLE IF NOT EXISTS  eg_bpa_auditdetails(
     id character varying(256)  NOT NULL,
     applicationno character varying(64),
     tenantid character varying(256),
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS  public.eg_bpa_auditdetails(
     accountid character varying(256) DEFAULT NULL::character varying
 );
 
-CREATE TABLE IF NOT EXISTS  public.eg_bpa_document(
+CREATE TABLE IF NOT EXISTS  eg_bpa_document(
     id character varying(64)  NOT NULL,
     documenttype character varying(64),
     filestoreid character varying(64),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the database migration process to remove an unnecessary schema reference when creating tables, enhancing internal consistency without affecting any user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->